### PR TITLE
Error support for Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "php": ">=5.6.4",
         "guzzlehttp/guzzle": "^6.3",
         "illuminate/events": "^5.7",
-        "illuminate/notifications": "^5.3",
-        "illuminate/support": "^5.1|^5.2|^5.3"
+        "illuminate/notifications": "^5.4",
+        "illuminate/support": "^5.4"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/src/FortySixElksChannel.php
+++ b/src/FortySixElksChannel.php
@@ -37,7 +37,7 @@ class FortySixElksChannel
                 try {
                     $media->send();
                 } catch(\Exception $e){
-                    $this->events->fire(new NotificationFailed($notifiable, $notification, get_class($this), ['exception' => $e]));
+                    $this->events->dispatch(new NotificationFailed($notifiable, $notification, get_class($this), ['exception' => $e]));
                 }
             }
 		}

--- a/src/FortySixElksMMS.php
+++ b/src/FortySixElksMMS.php
@@ -32,7 +32,6 @@ class FortySixElksMMS extends FortySixElksMedia
     public function send() {
 
         try {
-            echo 'doing request';
             $response = $this->client->request( 'POST', $this->endpoint, [
                 'form_params' => [
                     'from'     => $this->from,
@@ -42,15 +41,11 @@ class FortySixElksMMS extends FortySixElksMedia
                 ],
 
             ] );
-            echo 'did request';
-            var_dump($response);
         } catch ( \GuzzleHttp\Exception\BadResponseException $e ) {
             $response = $e->getResponse();
-            var_dump('WHOOT');
             throw CouldNotSendNotification::serviceRespondedWithAnError($response->getBody()->getContents(), $response->getStatusCode());
 
         }
-        echo "hmm";
         return $this;
     }
 

--- a/src/FortySixElksMMS.php
+++ b/src/FortySixElksMMS.php
@@ -44,7 +44,7 @@ class FortySixElksMMS extends FortySixElksMedia
             ] );
             echo 'did request';
             var_dump($response);
-        } catch ( GuzzleHttp\Exception\BadResponseException $e ) {
+        } catch ( \GuzzleHttp\Exception\BadResponseException $e ) {
             $response = $e->getResponse();
             var_dump('WHOOT');
             throw CouldNotSendNotification::serviceRespondedWithAnError($response->getBody()->getContents(), $response->getStatusCode());

--- a/src/FortySixElksSMS.php
+++ b/src/FortySixElksSMS.php
@@ -37,7 +37,7 @@ class FortySixElksSMS extends FortySixElksMedia implements FortySixElksMediaInte
 				],
 
 			] );
-		} catch ( GuzzleHttp\Exception\BadResponseException $e ) {
+		} catch ( \GuzzleHttp\Exception\BadResponseException $e ) {
 			$response = $e->getResponse();
 			throw CouldNotSendNotification::serviceRespondedWithAnError($response->getBody()->getContents(), $response->getStatusCode());
 		}


### PR DESCRIPTION
Hi.

The fire method was removed in 5.8. Using dispatch fixes this. See for example https://github.com/laravel-notification-channels/gcm/commit/f2b20d6b4232eaccb674571ef90223bf402f086b

And some small cleanup.